### PR TITLE
#8 - 초기 프로젝트 build.gradle 에 의존성 추가

### DIFF
--- a/pickgether/build.gradle
+++ b/pickgether/build.gradle
@@ -20,8 +20,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
+	
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 


### PR DESCRIPTION
초기 프로젝트에서 사용될 것으로 예상되는 것 위주로 build.gradle 에 추가

* Spring Data Jpa
* MySQL Driver -> 팀원들의 의견에 따라 MariaDB 로 수정될 수 있음
* Configuration Processor